### PR TITLE
Latest SDK & Size reduction

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ps2dev/ps2dev:v1.0
+    container: ps2dev/ps2dev:latest
     steps:
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+*.ELF
+*.o
+.vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ EE_BIN_STRIPPED = sd2psx_bl-stripped.ELF
 EE_OBJS = sd2psx_bl.o 
 EE_LIBS = -ldebug -lpatches -lmc
 NEWLIB_NANO = 1
+EE_CFLAGS += -Os
+EE_LDFLAGS += -s
 
 all:
 	$(MAKE) $(EE_BIN_PACKED)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ EE_BIN = sd2psx_bl.elf
 EE_BIN_PACKED = sd2psx_bl-packed.ELF
 EE_BIN_STRIPPED = sd2psx_bl-stripped.ELF
 EE_OBJS = sd2psx_bl.o 
-EE_LIBS = -ldebug -lc -lcdvd -lpatches -lfileXio -lmc 
+EE_LIBS = -ldebug -lpatches -lmc
+NEWLIB_NANO = 1
 
 all:
 	$(MAKE) $(EE_BIN_PACKED)

--- a/sd2psx_bl.c
+++ b/sd2psx_bl.c
@@ -85,8 +85,7 @@ static void loadKELF(char default_OSDSYS_path[], char ps2loc)
     char *args[4] = {arg0, arg1, arg2, arg3};
     char kelf_loader[40];
     int argc;
-    char path[1025];
-    
+    char path[32];
     if (default_OSDSYS_path[5] == '?')
     {
         default_OSDSYS_path[5] = ps2loc;

--- a/sd2psx_bl.c
+++ b/sd2psx_bl.c
@@ -9,11 +9,10 @@
 #include <input.h>
 #include <time.h>
 #include <string.h>
-#include <fileXio.h>
-#include <fileXio_rpc.h>
 #include <sbv_patches.h>
 #include <libmc.h>
 #include <stdbool.h>
+#include <fcntl.h>
 
 #ifndef MC_TYPE_MC
 #define MC_TYPE_MC 0
@@ -202,3 +201,24 @@ int main(int argc, char *argv[], char **envp)
 
     return 0;
 }
+
+/// Binary Size Reduction:
+#define DUMMY_TIMEZONE
+#define DUMMY_LIBC_INIT
+#define KERNEL_NOPATCH
+#if defined(DUMMY_TIMEZONE)
+   void _libcglue_timezone_update() {}
+#endif
+
+#if defined(DUMMY_LIBC_INIT)
+   void _libcglue_init() {}
+   void _libcglue_deinit() {}
+   void _libcglue_args_parse() {}
+#endif
+
+#if defined(KERNEL_NOPATCH)
+    DISABLE_PATCHED_FUNCTIONS();
+#endif
+
+DISABLE_EXTRA_TIMERS_FUNCTIONS();
+PS2_DISABLE_AUTOSTART_PTHREAD();


### PR DESCRIPTION
# Binary size reduction

I see you still use PS2DEV v1.0

so I made some changes:
1. Move to latest SDK - (unpacked (bytes): `155092` packed: `62820`, `ratio = 59.50%`)
2. Remove unused fileXio/cdvdman EE-RPC Libs (same size)
3. Apply all the newer SDK size reduction macros (save newlib nano) (unpacked: `101172` packed: `46228`, `ratio = 54.31%`)
4. add NEWLIB NANO to the mix - (unpacked: `37700` packed: `24324`, `35.48%`)

# I HAVENT TESTED THIS YET. BUT *SHOULD* WORK